### PR TITLE
Update premium_handler.py canged "is not" to "!=" line 140

### DIFF
--- a/premium_handler.py
+++ b/premium_handler.py
@@ -137,7 +137,7 @@ def is_valid_payment(address: str) -> bool:
         premium_price: int = int(str(os.environ.get('PKTEER_PREMIUM_PRICE')))
         # Check balance for the address
         balance = get_balance(address)
-        if (balance is not 0):
+        if (balance != 0):
             if balance < premium_price:
                 logging.info("Client paid %d, less than the premium price of %d", balance, premium_price)
                 return False


### PR DESCRIPTION
After server start with: ANODE_SERVER_PORT=8099 ./docker.sh
The following is outputted:
/server/premium_handler.py:140: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if (balance is not 0):